### PR TITLE
fix(windows): unblock release build on MSVC 14.51 coroutine hard error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,10 +249,10 @@ jobs:
           [Files]
           Source: "build\windows\x64\runner\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
           [Icons]
-          Name: "{group}\OpenLibExtended"; Filename: "{app}\OpenLibExtended.exe"
-          Name: "{autodesktop}\OpenLibExtended"; Filename: "{app}\OpenLibExtended.exe"
+          Name: "{group}\OpenLibExtended"; Filename: "{app}\OpenlibExtended.exe"
+          Name: "{autodesktop}\OpenLibExtended"; Filename: "{app}\OpenlibExtended.exe"
           [Run]
-          Filename: "{app}\OpenLibExtended.exe"; Description: "Launch OpenLibExtended"; Flags: nowait postinstall skipifsilent
+          Filename: "{app}\OpenlibExtended.exe"; Description: "Launch OpenLibExtended"; Flags: nowait postinstall skipifsilent
           "@ | Out-File -FilePath "installer.iss" -Encoding UTF8
           mkdir artifacts
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" installer.iss

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -32,6 +32,16 @@ set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}")
 # Use Unicode for all projects.
 add_definitions(-DUNICODE -D_UNICODE)
 
+# MSVC 14.51 (Visual Studio 2026) promoted the <experimental/coroutine>
+# deprecation to a hard error (STL1011). Two plugins still reach that header
+# through C++/WinRT: flutter_inappwebview_windows compiles as C++17, so
+# <winrt/base.h> falls back to the experimental header, and
+# permission_handler_windows builds with /await, which selects the experimental
+# coroutine machinery outright. Both are regenerated under
+# flutter/ephemeral/.plugin_symlinks by `flutter pub get`, so the opt-out is set
+# here, ahead of the plugin subdirectories below, to reach every plugin target.
+add_definitions(-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+
 # Compilation settings that should be applied to most targets.
 #
 # Be cautious about adding new options here, as plugins use this function by


### PR DESCRIPTION
## Problem

`flutter build windows --release` fails on `windows-latest`. Android, iOS and Linux are unaffected.

```
...\MSVC\14.51.36231\include\experimental\coroutine(37,1): error C2338:
static assertion failed: 'error STL1011: The /await compiler option,
<experimental/coroutine>, <experimental/generator>, and <experimental/resumable>
are deprecated by Microsoft and will be REMOVED SOON. ... You can define
_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS to suppress this error for now.'
```

Failing projects: `flutter_inappwebview_windows_plugin` and `permission_handler_windows_plugin`.

MSVC 14.51 (Visual Studio 2026) promoted the `<experimental/coroutine>` deprecation from a warning to a hard `static_assert`. This is a toolchain change on the hosted runner, so the build broke with no code change in the repo.

## Why those two plugins

Both reach the experimental header through C++/WinRT, for different reasons:

- `flutter_inappwebview_windows` compiles as C++17, so `__cpp_lib_coroutine` is undefined and `<winrt/base.h>` falls back to `<experimental/coroutine>`.
- `permission_handler_windows` builds with `/await`, which selects the pre-C++20 coroutine machinery outright.

Neither is patchable in-repo: both live under `windows/flutter/ephemeral/.plugin_symlinks/` and are regenerated by `flutter pub get`.

## Fix

One line in `windows/CMakeLists.txt`, beside the existing `add_definitions(-DUNICODE -D_UNICODE)`:

```cmake
add_definitions(-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
```

`add_definitions` sets a directory property that subdirectories inherit when they're added, and the plugins are added further down via `include(flutter/generated_plugins.cmake)`. Setting it here reaches each plugin target, including `flutter_inappwebview_windows`, which does not call `apply_standard_settings` (it defines its own copy to drop `/WX`), so patching that function alone would miss it.

Also points the Inno Setup shortcuts at `OpenlibExtended.exe`, matching `BINARY_NAME`. They previously said `OpenLibExtended.exe`; NTFS resolved that case-insensitively, but this seemed like a better-safe-than-sorry situation.

## Testing

- Windows build succeeds on `windows-latest`, Flutter 3.38.6, MSVC 14.51.36231
- Inno Setup produces `openlib-windows-x64-1.0.11.exe`; the bundle contains all five plugin DLLs plus `Webview2Loader.dll`
- Installer run on Windows: app launches, webview and permission flows work, book download tested successfully

No new dependencies, no app code touched. 2 files changed, +13 −3.